### PR TITLE
refactor @typescript-eslint/utils imports

### DIFF
--- a/.changeset/red-rings-trade.md
+++ b/.changeset/red-rings-trade.md
@@ -1,0 +1,5 @@
+---
+"@zphyrx/eslint-config": patch
+---
+
+Refactor `@typescript-eslint/utils` imports

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,8 +1,8 @@
 import { x } from "./src/index";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config: TSESLint.FlatConfig.ConfigArray = x(
+const config: FlatConfig.ConfigArray = x(
   {
     framework: false,
     testing: "vitest",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,17 +2,17 @@ import * as exlint from "@zphyrx/exlint";
 
 import { isArray, isObject } from "./utils";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 import type { ConfigWithExtends } from "@zphyrx/exlint";
 import type { ConfigOptions, FrameworkWithFlag } from "./types";
 
 const x = <F extends FrameworkWithFlag = false>(
   options: ConfigOptions<F> = {},
   ...configs: ConfigWithExtends[]
-): TSESLint.FlatConfig.ConfigArray => {
+): FlatConfig.ConfigArray => {
   const { testing = false } = options;
 
-  const cfgs: TSESLint.FlatConfig.ConfigArray = [
+  const cfgs: FlatConfig.ConfigArray = [
     {
       name: "@zphyrx/eslint-config/typescript",
       files: ["**/*.ts?(x)", "**/*.mts"],
@@ -45,7 +45,7 @@ const x = <F extends FrameworkWithFlag = false>(
 
 describe("x", (): void => {
   it("should return the config without vitest rules when `vitest` is disabled", (): void => {
-    const config: TSESLint.FlatConfig.ConfigArray = x({
+    const config: FlatConfig.ConfigArray = x({
       testing: false,
     });
 
@@ -62,7 +62,7 @@ describe("x", (): void => {
   });
 
   it("should return the config with vitest rules when `vitest` is enabled", (): void => {
-    const config: TSESLint.FlatConfig.ConfigArray = x({
+    const config: FlatConfig.ConfigArray = x({
       testing: "vitest",
     });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,14 +13,14 @@ import {
 } from "./configs";
 import { isArray, isObject } from "./utils";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 import type { ConfigWithExtends } from "@zphyrx/exlint";
 import type { ConfigOptions, FrameworkWithFlag } from "./types";
 
 const x = <F extends FrameworkWithFlag = false>(
   options: ConfigOptions<F> = {},
   ...configs: ConfigWithExtends[]
-): TSESLint.FlatConfig.ConfigArray => {
+): FlatConfig.ConfigArray => {
   const {
     framework = false,
     testing = false,
@@ -28,7 +28,7 @@ const x = <F extends FrameworkWithFlag = false>(
     storybook: enableStorybook = false,
     prettier: enablePrettier = false,
   } = options;
-  const cfgs: TSESLint.FlatConfig.ConfigArray = [
+  const cfgs: FlatConfig.ConfigArray = [
     ...ignores.config(),
     ...typescript.config(),
     ...importX.config(),

--- a/src/configs/_jsx-a11y.ts
+++ b/src/configs/_jsx-a11y.ts
@@ -1,9 +1,9 @@
 import * as exlint from "@zphyrx/exlint";
 import * as jsxA11y from "@zphyrx/eslint-config-jsx-a11y";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config = (): TSESLint.FlatConfig.ConfigArray =>
+const config = (): FlatConfig.ConfigArray =>
   exlint.config({
     extends: jsxA11y.extends,
     name: "@zphyrx/eslint-config/jsx-a11y",

--- a/src/configs/_testing-library.ts
+++ b/src/configs/_testing-library.ts
@@ -3,12 +3,12 @@ import * as configs from "@zphyrx/eslint-config-testing-library";
 
 import { isArray } from "../utils";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 import type { ConfigOptions, Framework, FrameworkWithFlag } from "../types";
 
 const config = <F extends FrameworkWithFlag = false>(
   options: Partial<ConfigOptions<F>> = {},
-): TSESLint.FlatConfig.ConfigArray => {
+): FlatConfig.ConfigArray => {
   const { framework: _framework = false } = options;
 
   const framework = (

--- a/src/configs/ignores.ts
+++ b/src/configs/ignores.ts
@@ -1,8 +1,8 @@
 import * as exlint from "@zphyrx/exlint";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config = (): TSESLint.FlatConfig.ConfigArray =>
+const config = (): FlatConfig.ConfigArray =>
   exlint.config({
     name: "@zphyrx/eslint-config/global-ignores",
     ignores: ["**/node_modules/**", "**/dist/**", "**/coverage/**"],

--- a/src/configs/import-x.ts
+++ b/src/configs/import-x.ts
@@ -1,9 +1,9 @@
 import * as exlint from "@zphyrx/exlint";
 import * as importX from "@zphyrx/eslint-config-import-x";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config = (): TSESLint.FlatConfig.ConfigArray =>
+const config = (): FlatConfig.ConfigArray =>
   exlint.config({
     extends: importX.extends,
     name: "@zphyrx/eslint-config/import-x",

--- a/src/configs/jest.ts
+++ b/src/configs/jest.ts
@@ -4,12 +4,12 @@ import * as jest from "@zphyrx/eslint-config-jest";
 import * as testingLibrary from "./_testing-library";
 import { isArray, isObject } from "../utils";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 import type { ConfigOptions, FrameworkWithFlag } from "../types";
 
 const config = <F extends FrameworkWithFlag = false>(
   options: Partial<ConfigOptions<F>> = {},
-): TSESLint.FlatConfig.ConfigArray => {
+): FlatConfig.ConfigArray => {
   const { testing = false } = options;
 
   const enableLib =

--- a/src/configs/prettier.ts
+++ b/src/configs/prettier.ts
@@ -1,9 +1,9 @@
 import * as exlint from "@zphyrx/exlint";
 import * as prettier from "@zphyrx/eslint-config-prettier";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config = (): TSESLint.FlatConfig.ConfigArray =>
+const config = (): FlatConfig.ConfigArray =>
   exlint.config({
     extends: prettier.extends,
     name: "@zphyrx/eslint-config/prettier",

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -4,12 +4,12 @@ import * as react from "@zphyrx/eslint-config-react";
 import * as jsxA11y from "./_jsx-a11y";
 import { isArray, isObject } from "../utils";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 import type { ConfigOptions, ReactOptions, FrameworkWithFlag } from "../types";
 
 const config = <F extends FrameworkWithFlag = false>(
   options: Partial<ConfigOptions<F>> = {},
-): TSESLint.FlatConfig.ConfigArray => {
+): FlatConfig.ConfigArray => {
   const { framework = false } = options;
 
   const enableJsxA11y =

--- a/src/configs/storybook.ts
+++ b/src/configs/storybook.ts
@@ -1,9 +1,9 @@
 import * as exlint from "@zphyrx/exlint";
 import * as storybook from "@zphyrx/eslint-config-storybook";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config = (): TSESLint.FlatConfig.ConfigArray =>
+const config = (): FlatConfig.ConfigArray =>
   exlint.config({
     extends: storybook.extends,
     name: "@zphyrx/eslint-config/storybook",

--- a/src/configs/tailwindcss.ts
+++ b/src/configs/tailwindcss.ts
@@ -1,9 +1,9 @@
 import * as exlint from "@zphyrx/exlint";
 import * as tailwindcss from "@zphyrx/eslint-config-tailwindcss";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config = (): TSESLint.FlatConfig.ConfigArray =>
+const config = (): FlatConfig.ConfigArray =>
   exlint.config({
     extends: tailwindcss.extends,
     name: "@zphyrx/eslint-config/tailwindcss",

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -1,9 +1,9 @@
 import * as exlint from "@zphyrx/exlint";
 import * as typescript from "@zphyrx/eslint-config-typescript";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-const config = (): TSESLint.FlatConfig.ConfigArray =>
+const config = (): FlatConfig.ConfigArray =>
   exlint.config({
     extends: typescript.extends,
     name: "@zphyrx/eslint-config/typescript",

--- a/src/configs/vitest.ts
+++ b/src/configs/vitest.ts
@@ -4,12 +4,12 @@ import * as vitest from "@zphyrx/eslint-config-vitest";
 import * as testingLibrary from "./_testing-library";
 import { isArray, isObject } from "../utils";
 
-import type { TSESLint } from "@typescript-eslint/utils";
+import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 import type { ConfigOptions, FrameworkWithFlag } from "../types";
 
 const config = <F extends FrameworkWithFlag = false>(
   options: Partial<ConfigOptions<F>> = {},
-): TSESLint.FlatConfig.ConfigArray => {
+): FlatConfig.ConfigArray => {
   const { testing = false } = options;
 
   const enableLib =


### PR DESCRIPTION
### Description

This PR refactors the imports for `@typescript-eslint/utils` throughout the codebase.

Specifically, it changes from:

```ts
import type { TSESLint } from "@typescript-eslint/utils";
```
to:
```ts
import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
```
